### PR TITLE
Add supplier item reservation calendar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import CarsPage from './admin/CarsPage';
 import AddContentPage from './admin/AddContentPage';
 import BookingsPage from './admin/BookingsPage';
 import SupplierDashboard from './admin/SupplierDashboard';
+import ItemCalendarPage from './admin/ItemCalendarPage';
 
 
 function App() {
@@ -44,6 +45,7 @@ function App() {
           <Route path="/admin/dashboard" element={<ProtectedRoute><SupplierDashboard /></ProtectedRoute>} />
           <Route path="/admin/super/dashboard" element={<ProtectedRoute><SuperDashboard /></ProtectedRoute>} />
           <Route path="/admin/supplier/:supplierId" element={<ProtectedRoute><SupplierDashboard /></ProtectedRoute>} />
+          <Route path="/admin/items/:type/:itemId/calendar" element={<ProtectedRoute><ItemCalendarPage /></ProtectedRoute>} />
           <Route path="/admin/excursions" element={<ProtectedRoute><ExcursionsPage /></ProtectedRoute>} />
           <Route path="/admin/cars" element={<ProtectedRoute><CarsPage /></ProtectedRoute>} />
           <Route path="/admin/add" element={<ProtectedRoute><AddContentPage /></ProtectedRoute>} />

--- a/src/admin/ItemCalendarPage.jsx
+++ b/src/admin/ItemCalendarPage.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import { useTranslation } from 'react-i18next';
+import 'react-datepicker/dist/react-datepicker.css';
+import '../pages/ExcursionDatePage.css';
+import BackButton from '../components/BackButton';
+import ru from 'date-fns/locale/ru';
+import en from 'date-fns/locale/en-US';
+
+const ItemCalendarPage = () => {
+  const { type, itemId } = useParams();
+  const { t, i18n } = useTranslation();
+  const [unavailableDates, setUnavailableDates] = useState([]);
+  const [date, setDate] = useState(null);
+  const [range, setRange] = useState([null, null]);
+  const [success, setSuccess] = useState('');
+  const [reservations, setReservations] = useState([]);
+  const [itemName, setItemName] = useState('');
+  const [showCalendar, setShowCalendar] = useState(false);
+
+  useEffect(() => {
+    registerLocale('ru', ru);
+    registerLocale('en', en);
+  }, []);
+
+  const loadReservations = () => {
+    const endpoint = type === 'car' ? 'car-reservations' : 'excursion-reservations';
+    fetch(`https://booking-backend-tjmn.onrender.com/${endpoint}?${type}_id=${itemId}`)
+      .then(res => res.json())
+      .then(data => {
+        setReservations(data);
+        let dates;
+        if (type === 'car') {
+          dates = data.map(d => {
+            const [y, m, d2] = (d.start_date || d).split('-');
+            return new Date(+y, +m - 1, +d2);
+          });
+        } else {
+          dates = data.map(d => {
+            const [y, m, d2] = (d.date || d).split('-');
+            return new Date(+y, +m - 1, +d2);
+          });
+        }
+        setUnavailableDates(dates);
+      })
+      .catch(err => console.error('Failed to load reservations', err));
+  };
+
+  useEffect(() => {
+    loadReservations();
+    const itemEndpoint = type === 'car' ? 'cars' : 'excursions';
+    fetch(`https://booking-backend-tjmn.onrender.com/api/admin/${itemEndpoint}/${itemId}`, {
+      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+    })
+      .then(res => res.json())
+      .then(data => {
+        const name = type === 'car' ? `${data.brand} ${data.model}` : data.title;
+        setItemName(name);
+      })
+      .catch(err => console.error('Failed to load item', err));
+  }, [type, itemId]);
+
+  const format = d => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+  const handleSave = async () => {
+    const endpoint = type === 'car' ? 'car-reservations' : 'excursion-reservations';
+    const payload =
+      type === 'car'
+        ? { car_id: parseInt(itemId, 10), start_date: format(range[0]), end_date: format(range[1]) }
+        : { excursion_id: parseInt(itemId, 10), date: format(date) };
+
+    const res = await fetch(`https://booking-backend-tjmn.onrender.com/${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+      body: JSON.stringify(payload)
+    });
+    if (res.ok) {
+      setSuccess(t('suppliers.ReservationSaved'));
+      setTimeout(() => setSuccess(''), 3000);
+      setShowCalendar(false);
+      setDate(null);
+      setRange([null, null]);
+      loadReservations();
+    } else {
+      alert('Error');
+    }
+  };
+
+  const handleDelete = async id => {
+    const endpoint = type === 'car' ? 'car-reservations' : 'excursion-reservations';
+    await fetch(`https://booking-backend-tjmn.onrender.com/${endpoint}/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+    });
+    loadReservations();
+  };
+
+  const [start, end] = range;
+  return (
+    <div className="date-page-wrapper">
+      <h2 className="date-page-title">{t('suppliers.ReserveDates')}</h2>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>{t('suppliers.ItemID')}</th>
+            <th>{t('suppliers.Name')}</th>
+            <th>{type === 'car' ? t('suppliers.Period') : t('suppliers.Date')}</th>
+            <th>{t('suppliers.Actions')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {reservations.map(r => (
+            <tr key={r.id}>
+              <td>{itemId}</td>
+              <td>{itemName}</td>
+              <td>
+                {type === 'car'
+                  ? `${r.start_date} - ${r.end_date}`
+                  : r.date}
+              </td>
+              <td>
+                <button className="delete-btn" onClick={() => handleDelete(r.id)}>
+                  {t('suppliers.DeleteButton')}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {showCalendar && (
+        <div className="datepicker-container">
+          {type === 'car' ? (
+            <DatePicker
+              selected={start}
+              onChange={setRange}
+              startDate={start}
+              endDate={end}
+              minDate={new Date()}
+              excludeDates={unavailableDates}
+              selectsRange
+              inline
+              calendarClassName="custom-calendar"
+              dateFormat="yyyy-MM-dd"
+              locale={i18n.language === 'ru' ? 'ru' : 'en'}
+            />
+          ) : (
+            <DatePicker
+              selected={date}
+              onChange={d => setDate(d)}
+              minDate={new Date()}
+              excludeDates={unavailableDates}
+              inline
+              calendarClassName="custom-calendar"
+              dateFormat="yyyy-MM-dd"
+              locale={i18n.language === 'ru' ? 'ru' : 'en'}
+            />
+          )}
+          <button
+            onClick={handleSave}
+            className="continue-button"
+            disabled={type === 'car' ? !start || !end : !date}
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      )}
+
+      {success && <p className="success-message">{success}</p>}
+
+      <button onClick={() => setShowCalendar(!showCalendar)} className="continue-button">
+        {t('suppliers.AddButton')}
+      </button>
+
+      <BackButton />
+    </div>
+  );
+};
+
+export default ItemCalendarPage;

--- a/src/admin/LoginPage.jsx
+++ b/src/admin/LoginPage.jsx
@@ -48,7 +48,7 @@ const LoginPage = () => {
       }
             
       navigate(data.is_superuser ? "/admin/super/dashboard" : "/admin/dashboard");
-    } catch (err) {
+    } catch {
       setError(t("login.error_network", "Ошибка сети"));
     } finally {
       setIsLoading(false);

--- a/src/admin/SupplierDashboard.jsx
+++ b/src/admin/SupplierDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import "./SupplierDashboard.css";
 
@@ -457,7 +457,11 @@ const SupplierDashboard = () => {
                   {supplier?.supplier_type === "cars" ? (
                     <>
                       <td>{item.id}</td>
-                      <td>{item.brand}</td>
+                      <td>
+                        <Link to={`/admin/items/car/${item.id}/calendar`}>
+                          {item.brand}
+                        </Link>
+                      </td>
                       <td>{item.model}</td>
                       <td>{item.color}</td>
                       <td>{item.price_per_day}</td>
@@ -471,7 +475,11 @@ const SupplierDashboard = () => {
                   ) : supplier?.supplier_type === "excursion" ? (
                     <>
                       <td>{item.id}</td>
-                      <td>{item.title}</td>
+                      <td>
+                        <Link to={`/admin/items/excursion/${item.id}/calendar`}>
+                          {item.title}
+                        </Link>
+                      </td>
                       <td>{item.price}</td>
                       <td>{item.location_en}</td>
                       <td>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -299,6 +299,10 @@
     "ProfileUpdated": "Profile updated successfully",
     "Actions": "Actions",
     "AddNewCar": "Add New Car",
-    "AddNewExcursion": "Add New Excursion"
+    "AddNewExcursion": "Add New Excursion",
+    "ReserveDates": "Reserve Dates",
+    "ReservationSaved": "Dates saved",
+    "Name": "Name",
+    "Period": "Period"
   }
 }

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -299,6 +299,10 @@
     "ProfileUpdated": "Профиль успешно обновлён",
     "Actions": "Действия",
     "AddNewCar": "Добавить новый автомобиль",
-    "AddNewExcursion": "Добавить новую экскурсию"
+    "AddNewExcursion": "Добавить новую экскурсию",
+    "ReserveDates": "Резервирование дат",
+    "ReservationSaved": "Даты сохранены",
+    "Name": "Название",
+    "Period": "Период"
   }
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,11 +4,7 @@ import { useTranslation } from 'react-i18next';
 import './Home.css';
 
 const Home = () => {
-  const { t, i18n } = useTranslation();
-
-  const changeLanguage = (lng) => {
-    i18n.changeLanguage(lng);
-  };
+  const { t } = useTranslation();
 
   return (
     <div className="home-wrapper">


### PR DESCRIPTION
## Summary
- allow suppliers to manage item reservations
- show existing reservations with delete option
- toggle calendar to add a new reservation
- localize new calendar table headers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68495c76b57c8326a78a3418570163c3